### PR TITLE
Fix for yooclick.com

### DIFF
--- a/src/sites/link/yooclick.com.js
+++ b/src/sites/link/yooclick.com.js
@@ -5,15 +5,29 @@ $.register({
 
     $.removeNodes('iframe');
 
-    var uniq = unsafeWindow.uniq;
+    var uniq = unsafeWindow.uniq || unsafeWindow.uniqi;
+    if (!uniq) {return;}
     var path = window.location.pathname;
     // this site doesn't really parse the query string
     // the order of param matters
     var url = _.T('{0}?ajax=true&adblock=false&old=false&framed=false&uniq={1}')(path, uniq);
-    $.get(url, {
-    }, function (text) {
-      $.openLink(text);
-    });
+    
+    var getURL = function() {
+      $.get(url, {
+      }, function (text) {
+        // Check if text is a valid URL or not
+        var goodURL = /^(https?|ftp):\/\/(((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:)*@)?(((\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5])\.(\d|[1-9]\d|1\d\d|2[0-4]\d|25[0-5]))|((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?)(:\d*)?)(\/((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)+(\/(([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)*)*)?)?(\?((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|[\uE000-\uF8FF]|\/|\?)*)?(\#((([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(%[\da-f]{2})|[!\$&'\(\)\*\+,;=]|:|@)|\/|\?)*)?$/i.test(text);
+        // Found a valid URL?
+        if (goodURL) {
+          $.openLink(text);
+        // Try later, the server probably returned a page instead of a link
+        } else {
+          setTimeout(getURL, 500);
+        }
+      });
+    }
+
+    getURL();
   },
 });
 


### PR DESCRIPTION
- fixed yooclick.com
- fixed a bug which redirected even if the URL is not valid (usually
  happens the first time because the server doesn't return the URL if
  countdown is skipped too quickly), retry if URL is not valid

Example link: http://www.yooclick.com/l/hyqi2f
