### PR TITLE
Fix Linkbucks

### DIFF
--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -619,6 +619,7 @@ var $;
         },
       };
       _.C([unsafeWindow, unsafeWindow.document.body]).each(function (o) {
+        if (o == null) {return;}
         // release existing events
         o.onbeforeunload = undefined;
         // prevent they bind event again


### PR DESCRIPTION
- Fix disableLeavePrompt(): Sometimes, unsafeWindow or unsafeWindow.document.body did not exist,
  this caused the function to throw an error.
