### PR TITLE
Add support for ysear.ch iframed links

### DIFF
--- a/src/sites/link/bc.vc.js
+++ b/src/sites/link/bc.vc.js
@@ -194,7 +194,7 @@
 
   $.register({
     rule: {
-      host: /^(adcrun|ysear)\.ch|(fly2url|urlwiz|xafox)\.com|(zpoz|ultry)\.net|(wwy|myam)\.me|ssl\.gs|link\.tl|xip\.ir|hit\.us|shortit\.in|(adbla|tl7)\.us|www\.adjet\.eu|srk\.gs|cun\.bz$/,
+      host: /^adcrun\.ch|(fly2url|urlwiz|xafox)\.com|(zpoz|ultry)\.net|(wwy|myam)\.me|ssl\.gs|link\.tl|xip\.ir|hit\.us|shortit\.in|(adbla|tl7)\.us|www\.adjet\.eu|srk\.gs|cun\.bz$/,
       path: /^\/.+/,
     },
     ready: run,
@@ -202,7 +202,7 @@
 
   $.register({
     rule: {
-      host: /^adtr\.im$/,
+      host: /^adtr\.im|ysear\.ch$/,
       path: /^\/.+/,
     },
     ready: function(){


### PR DESCRIPTION
Example link by annlabv3: http://safeurl.eu/1A
