### PR TITLE
Add context to $.searchScripts()

### DIFF
--- a/src/util/dom.js
+++ b/src/util/dom.js
@@ -294,8 +294,8 @@ var $;
       });
     };
 
-    $.searchScripts = function (pattern) {
-      var m = $.$$('script').find(function (s) {
+    $.searchScripts = function (pattern, context) {
+      var m = $.$$('script', context).find(function (s) {
         var m = s.innerHTML.match(pattern);
         if (!m) {
           return _.nop;


### PR DESCRIPTION
This allows to use a different context than the default.
