### PR TITLE
Fix lienscash.com

### DIFF
--- a/src/sites/link/lienscash.com.js
+++ b/src/sites/link/lienscash.com.js
@@ -3,10 +3,8 @@ $.register({
   ready: function () {
     'use strict';
 
-    $.removeNodes('iframe');
-
-    var a = $('#time a');
-    $.openLink(a.id);
+    var a = $('#redir_btn');
+    $.openLink(a.href);
   },
 });
 


### PR DESCRIPTION
It's OK now for links with or without subdomain, means:
http://www.example.com = http://example.com
