### PR TITLE
Fix imagezilla.net

### DIFF
--- a/src/sites/image/imagezilla.js
+++ b/src/sites/image/imagezilla.js
@@ -1,12 +1,13 @@
 $.register({
   rule: {
     host: /^imagezilla\.net$/,
-    path: /^\/show\/(.+)$/,
   },
-  start: function (m) {
+  ready: function () {
     'use strict';
-
-    $.openImage('/images2/' + m.path[1]);
+    var i = $('#photo');
+    $.openLink(i.src, {
+      referer: true,
+    });
   },
 });
 


### PR DESCRIPTION
Hi legnaleurc,

this fixes 
* imagezilla.net by using referer (must set, otherwise it dont work)
* also fixes random url (/images\d{1}/) and
* avoids conflict with Handy Image (https://greasyfork.org/forum/discussion/1054/imagezilla-net-failure)

test:
http://imagezilla.net/show/7044460-20130131-181616.jpg (/images2/)
http://imagezilla.net/show/D5bfNQ3-20140104-145044.jpg (/images/)