### PR TITLE
Update image scripts with 'rule' object without 'path'

### DIFF
--- a/src/sites/image/beeimg.js
+++ b/src/sites/image/beeimg.js
@@ -1,6 +1,7 @@
 $.register({
   rule: {
     host: /^beeimg\.com$/,
+    path: /\/view\/.*/
   },
   ready: function () {
     'use strict';


### PR DESCRIPTION
Randomly checked two image scripts and I cannot access to homepage in one of them (beeimg.com).
If you set a 'rule' object with only the 'host' part (and no 'path'), this rule includes the home page, used frequently to let the users upload images.
I am too lazy to check all other scripts, so i don't know if this apply to others.
Maybe this should be an issue.
