### PR TITLE
fix for www.hotimage.uk

### DIFF
--- a/src/sites/image/reklama.js
+++ b/src/sites/image/reklama.js
@@ -69,7 +69,7 @@
           /^vava\.in$/,
           /^(pixxx|picspornfree|imgload)\.me$/,
           /^(porno-pirat|24avarii|loftlm|18pron)\.ru$/,
-          /^hotimage\.uk$/,
+          /^www.hotimage\.uk$/,
           /^imgease\.re$/,
           /^goimg\.xyz$/,
           /^pic2pic\.site$/,


### PR DESCRIPTION
The website redirects all requests to sub-domain that starts with "www"