### PR TITLE
bug fix for imagepearl.com and imageberyl.com

### DIFF
--- a/src/sites/image/abload.js
+++ b/src/sites/image/abload.js
@@ -1,38 +1,32 @@
 (function () {
   'use strict';
-
   function run () {
     var i = $('#image');
     $.openImage(i.src);
   }
-
   $.register({
     rule: {
       host: /^(www\.)?image(pearl|beryl)\.com$/,
-      path: /^\/(verify|view)\/(.+)$/,
+      path: /^\/(verify|image)\/(.+)$/,
     },
     start: function (m) {
-      $.openLink('/image/' + m.path[2], {
+      $.openLink('/view/' + m.path[2], {
         referer: false,
       });
     },
   });
-
   $.register({
     rule: [
       'http://*.abload.de/image.php?img=*',
       'http://www.imageup.ru/*/*/*.html',
-      // different layout same handler
       'http://itmages.ru/image/view/*/*',
-      // different layout same handler
       {
         host: /^(www\.)?image(pearl|beryl)\.com$/,
-        path: /^\/image\//,
+        path: /^\/view\//,
       },
     ],
     ready: run,
   });
-
 })();
 
 // ex: ts=2 sts=2 sw=2 et


### PR DESCRIPTION
tested with following [NSFW] urls
http://www.imagepearl.com/view/im1v97k8pt
http://www.imageberyl.com/image/im1v61rt2f

It works perfectly fine on Chrome however, I got infinite loop on FireFox. I couldn't work out why this is happening.

I reckon it might be because of Firefox interpreting the scripts differently. I'm sure you'll work something out.