### PR TITLE
bug fix for imagesnake.com & freebunker.com

### DIFF
--- a/src/sites/image/imagesnake.com.js
+++ b/src/sites/image/imagesnake.com.js
@@ -3,7 +3,9 @@
 
   function run () {
     var i = $('#img_obj');
-    $.openImage(i.src);
+    $.openImage(i.src, {
+      referer: true,
+    });
   }
 
   function run2 () {


### PR DESCRIPTION
Although it works on Chrome just fine, without referer both imagesnake.com and freebunker.com redirects you to "hot linking stinks" page on FireFox.

Tested with following [NSFW] links
http://www.imagesnake.com/show/49469/1.jpg
http://www.freebunker.com/show/55967/1.jpg