### PR TITLE
Fix for button selector

### DIFF
--- a/src/sites/link/coinlink.co.js
+++ b/src/sites/link/coinlink.co.js
@@ -6,7 +6,7 @@ $.register({
   ready: function (m) {
     'use strict';
 
-    var a = $('a.btn.btn-block.btn-warning');
+    var a = $('a#btn-main');
     $.openLink(a.href);
   },
 });


### PR DESCRIPTION
$('a.btn.btn-block.btn-warning'); -> This selector doesn't work. This site use reCaptcha. When confirm the captcha you will get link button. The button's id is btn-main.