### PR TITLE
pixsense.net

### DIFF
--- a/src/sites/image/pixsense.net.js
+++ b/src/sites/image/pixsense.net.js
@@ -18,8 +18,8 @@ $.register({
   ready: function () {
     'use strict';
 
-    var i = $('#myUniqueImg');
-    $.openLink(i.src);
+    var a = $('#myUniqueImg').parentNode;
+    $.openLink(i.href);
   },
 });
 

--- a/src/sites/image/pixsense.net.js
+++ b/src/sites/image/pixsense.net.js
@@ -19,7 +19,7 @@ $.register({
     'use strict';
 
     var a = $('#myUniqueImg').parentNode;
-    $.openLink(i.href);
+    $.openLink(a.href);
   },
 });
 


### PR DESCRIPTION
pixsense.net was stuck in a redirect loop because the img src gets set after the DOM is loaded via js. 

Getting the image link from the parent `a` node seems less hacky than waiting since it's there on first load.

Example link: https://www.pixsense.net/site/v/14280#17&14280