### PR TITLE
add short.awsubs.co

### DIFF
--- a/src/sites/link/sylnk.net.js
+++ b/src/sites/link/sylnk.net.js
@@ -182,6 +182,7 @@ $.register({
 $.register({
   rule: {
     host: /^ww[23]\.picnictrans\.com$/,
+    host: /^short\.awsubs\.co$/,
   },
   ready: function () {
     'use strict';


### PR DESCRIPTION
add short.awsubs.co

example link: 
http://short.awsubs.co/tx9kh
http://short.awsubs.co/emGTt

#1427 