### PR TITLE
Add support for imgtorrnt.in

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -783,7 +783,6 @@
     * imgcarry.com
     * imgdollar.com
     * imgtheif.com
-    * imgtorrnt.in
     * imgvault.pw
     * indexmovie.xyz
     * iori.us

--- a/SITES.md
+++ b/SITES.md
@@ -783,6 +783,7 @@
     * imgcarry.com
     * imgdollar.com
     * imgtheif.com
+    * imgtorrnt.in
     * imgvault.pw
     * indexmovie.xyz
     * iori.us

--- a/src/sites/image/imgtorrnt.in.js
+++ b/src/sites/image/imgtorrnt.in.js
@@ -7,7 +7,7 @@ $.register({
   ready: function () {
     'use strict';
 
-    let img = $('center div table.tg tbody tr td center img');
+    var img = $('center div table.tg tbody tr td center img');
     $.openImage(img.src);
   }
 });

--- a/src/sites/image/imgtorrnt.in.js
+++ b/src/sites/image/imgtorrnt.in.js
@@ -1,0 +1,13 @@
+$.register({
+  rule: {
+    host: /^imgtorrnt.in$/,
+    path: /^\/view\.php$/,
+    query: /^\?id=.*/,
+  },
+  ready: function () {
+    'use strict';
+
+    let img = $('center div table.tg tbody tr td center img');
+    $.openImage(img.src);
+  }
+});


### PR DESCRIPTION
This site is basically embedding imgur but just to be
on the safe side for now we just read `src` of the image instead of the id in the url.