### PR TITLE
Update abload.js

### DIFF
--- a/src/sites/image/abload.js
+++ b/src/sites/image/abload.js
@@ -8,11 +8,13 @@
 
   $.register({
     rule: {
-      host: /^(www\.)?image(pearl|beryl|crest)\.com$/,
+      host: /^(www\.)?image(pearl|crest)\.com$/,
       path: /^\/verify\/(.+)$/,
     },
     start: function (m) {
-      $.openLink('/view/' + m.path[1]);
+      $.openLink('/view/' + m.path[1], {
+        referer: false
+      });
     },
   });
 
@@ -24,7 +26,7 @@
       'http://itmages.ru/image/view/*/*',
       // different layout same handler
       {
-        host: /^(www\.)?image(pearl|beryl|crest)\.com$/,
+        host: /^(www\.)?image(pearl|crest)\.com$/,
         path: /^\/view\//,
       },
     ],

--- a/src/sites/image/abload.js
+++ b/src/sites/image/abload.js
@@ -12,7 +12,9 @@
       path: /^\/verify\/(.+)$/,
     },
     start: function (m) {
-      $.openLink('/view/' + m.path[1]);
+      $.openLink('/view/' + m.path[1], {
+        referer: false,
+      });
     },
   });
 

--- a/src/sites/image/abload.js
+++ b/src/sites/image/abload.js
@@ -8,13 +8,11 @@
 
   $.register({
     rule: {
-      host: /^(www\.)?image(pearl|crest)\.com$/,
+      host: /^(www\.)?image(pearl|beryl|crest)\.com$/,
       path: /^\/verify\/(.+)$/,
     },
     start: function (m) {
-      $.openLink('/view/' + m.path[1], {
-        referer: false
-      });
+      $.openLink('/view/' + m.path[1]);
     },
   });
 
@@ -26,7 +24,7 @@
       'http://itmages.ru/image/view/*/*',
       // different layout same handler
       {
-        host: /^(www\.)?image(pearl|crest)\.com$/,
+        host: /^(www\.)?image(pearl|beryl|crest)\.com$/,
         path: /^\/view\//,
       },
     ],


### PR DESCRIPTION
Both imagepearl.com and imagecrest.com are stuck in an endless loop currently. Opening the link without referer fixes this.

Also remove imageberyl.com as the domain is no longer operating. 

Example image:
http://www.imagepearl.com/verify/im1wmu0dd9
http://www.imagecrest.com/verify/im1wmu0dd9