### PR TITLE
Update adlink.guru.js

### DIFF
--- a/src/sites/link/adlink.guru.js
+++ b/src/sites/link/adlink.guru.js
@@ -13,7 +13,7 @@
         /^urle\.co$/,
         /^(hashe|trlink|adshort)\.in$/,
         /^www\.worldhack\.net$/,
-        /^123link\.top$/,
+        /^123link\.(io|top)$/,
         /^pir\.im$/,
         /^bol\.tl$/,
         /^(tl|adfly)\.tc$/,


### PR DESCRIPTION
Solves: #1604,#1748
123link.top redirects to 123link.io, so code now supports both domains.