### PR TITLE
short.pe

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -61,6 +61,7 @@
       host: [
         /^adlink\.guru$/,
         /^clik\.pw$/,
+        /^short\.pe$/,
         /^coshurl\.co$/,
         /^curs\.io$/,
         /^cypt\.ga$/,


### PR DESCRIPTION
new domain for clik.pw on linkdrop.net.js
#1890 