### PR TITLE
add imagexport.com

### DIFF
--- a/src/sites/image/imagetwist.js
+++ b/src/sites/image/imagetwist.js
@@ -16,9 +16,13 @@
   });
 
   _.register({
-    rule: {
-      host: /^imagetwist\.com$/,
-    },
+    rule: [
+      {
+        host: [
+          /^(imagetwist|imagexport)\.com$/,
+        ],
+      },
+    ],
     ready: _.partial(run, false),
   });
 

--- a/src/sites/image/reklama.js
+++ b/src/sites/image/reklama.js
@@ -142,6 +142,7 @@
       host: [
         /^(www\.)?img(adult|wallet|taxi)\.com$/,
         /^(www\.)?imgdrive\.net$/,
+        /^(www\.)?imgfresh\.info$/,
       ],
       path: /^\/img-.*\.html$/,
     },


### PR DESCRIPTION
it's a domain that actually redirects to imagetwist.com

tested with following [NSFW] url :
http://imagexport.com/zw10g75sc0vk/xvsr315sopl.jpg