### PR TITLE
fixes coinlink.co

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -87,6 +87,7 @@
         /^adshort\.im$/,
         /^adshorte\.com$/,
         /^weefy\.me$/,
+        /^coinlink\.co$/
       ],
     },
     async ready () {

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -87,7 +87,7 @@
         /^adshort\.im$/,
         /^adshorte\.com$/,
         /^weefy\.me$/,
-        /^coinlink\.co$/
+        /^coinlink\.co$/,
       ],
     },
     async ready () {


### PR DESCRIPTION
adding coinlink.co to linkdrop.net.js; instead of its own snippet..
#1920 
