### PR TITLE
Delete chevereto.js

### DIFF
--- a/src/sites/image/chevereto.js
+++ b/src/sites/image/chevereto.js
@@ -1,7 +1,0 @@
-_.register({
-  rule: 'http://javelite.tk/viewer.php?id=*',
-  async ready () {
-    const i = $('table img');
-    await $.openImage(i.src);
-  },
-});


### PR DESCRIPTION
site redirects to garbage page, therefore we should not support it.
http://javelite.tk/viewer.php?id=446KOOPO_48.jpg

as doing the edit through github web, i cannot physically delete the script.