### PR TITLE
Update dailyss.net.js

### DIFF
--- a/src/sites/image/dailyss.net.js
+++ b/src/sites/image/dailyss.net.js
@@ -2,9 +2,6 @@ _.register({
   rule: {
     host: [
       /^dailyss\.net$/,
-      /daily-img\.com$/,
-      /img-365\.com$/,
-      /^365-img\.com$/,
       /^i\.hentai-ddl\.org$/,
       /^imghost\.top$/,
     ],
@@ -13,17 +10,5 @@ _.register({
   async ready () {
     const i = $('#image-viewer-container img');
     await $.openImage(i.src);
-  },
-});
-
-_.register({
-  rule: {
-    host: /^xxx\.porn0day\.com$/,
-    path: /^\/image\/.+$/,
-  },
-  async ready () {
-    // the URL in img is a thumbnail
-    const i = $('link[rel^=image_src]');
-    await $.openImage(i.href);
   },
 });


### PR DESCRIPTION
these domains expire:
daily-img.com, img-365.com, 365-img.com, xxx.porn0day.com