### PR TITLE
Update emptypix.js

### DIFF
--- a/src/sites/image/emptypix.js
+++ b/src/sites/image/emptypix.js
@@ -2,32 +2,14 @@ _.register({
   rule: [
     {
       host: [
-        /^(emptypix|imgdomino)\.com$/,
         /^overdream\.cz$/,
         /^www\.sexseeimage\.com$/,
       ],
       path: /^\/image\//,
     },
-    {
-      host: /^10\.imageleon\.com$/,
-      path: /^\/img-(.+)\.html$/,
-    },
   ],
   async ready () {
     const img = $('#full_image');
     await $.openImage(img.src);
-  },
-});
-
-_.register({
-  rule: {
-    host: /^sexyxpixels\.com$/,
-    query: /^\?v=/,
-  },
-  async ready () {
-    const img = $('#full_image');
-    await $.openImage(img.src, {
-      referer: true,
-    });
   },
 });


### PR DESCRIPTION
domains are gone:
imgdomino.com, emptypix.com, 10.imageleon.com, sexyxpixels.com