### PR TITLE
Delete vvcap.js

### DIFF
--- a/src/sites/image/vvcap.js
+++ b/src/sites/image/vvcap.js
@@ -1,9 +1,0 @@
-_.register({
-  rule: 'http://vvcap.net/db/*.htp',
-  async ready () {
-    const i = $('img');
-    await $.openImage(i.src, {
-      replace: true,
-    });
-  },
-});


### PR DESCRIPTION
vvcap.net redirects to vvcap.com
when have a sample link for vvcap:   https://vvcap.com/img/pYmfGSK0Lvt.jpg
no popup/countdown occurs.