### PR TITLE
Update mihalism.js

### DIFF
--- a/src/sites/image/mihalism.js
+++ b/src/sites/image/mihalism.js
@@ -4,12 +4,9 @@
   _.register({
     rule: {
       host: [
-        /^(miragepics|funextra\.hostzi|imgrex|img3x)\.com$/,
+        /^(miragepics|funextra\.hostzi)\.com$/,
         /^bilder\.nixhelp\.de$/,
         /^imagecurl\.(com|org)$/,
-        /^imagevau\.eu$/,
-        /^img\.deli\.sh$/,
-        /^imgsicily\.it$/,
         /^www\.imghere\.net$/,
       ],
       path: /^\/viewer\.php$/,
@@ -23,7 +20,6 @@
     rule: {
       host: [
         /^(dwimg|imgsin)\.com$/,
-        /^www\.pictureshoster\.com$/,
       ],
       path: /^\/viewer\.php$/,
       query: /file=([^&]+)/,


### PR DESCRIPTION
domains gone:
- imgrex.com
- img3x.com
- imagevau.eu
- img.deli.sh
- imgsicily.it
- pictureshoster.com