### PR TITLE
Update imgpaying.com.js

### DIFF
--- a/src/sites/image/imgpaying.com.js
+++ b/src/sites/image/imgpaying.com.js
@@ -224,16 +224,6 @@
     return i.value;
   }
 
-  function getNext2 (i) {
-    let next = i.onclick && i.onclick.toString().match(/value='([^']+)'/);
-    if (next) {
-      next = next[1];
-      return next;
-    } else {
-      return i.value;
-    }
-  }
-
   async function helper (id, getNext) {
     const recaptcha = $.$('#recaptcha_widget, #captcha');
     if (recaptcha) {

--- a/src/sites/image/imgpaying.com.js
+++ b/src/sites/image/imgpaying.com.js
@@ -5,16 +5,11 @@
   _.register({
     rule: {
       host: [
-        /^img(universal|paying|mega|zeus|monkey|trex|ve|dew|diamond)\.com$/,
+        /^img(monkey|trex|ve|dew|diamond)\.com$/,
         /^(www\.)?imgsee\.me$/,
-        /^img(click|maid)\.net$/,
-        /^(uploadrr|imageeer|imzdrop|www\.uimgshare|pic-maniac|hulkimge)\.com$/,
-        /^imgdrive\.co$/,
-        /^cuteimg\.cc$/,
-        /^img(tiger|gold)\.org$/,
-        /^myimg\.club$/,
-        /^foxyimg\.link$/,
-        /^(core|iron)img\.net$/,
+        /^imgclick\.net$/,
+        /^(uploadrr|imageeer|www\.uimgshare|pic-maniac|hulkimge)\.com$/,
+        /^ironimg\.net$/,
       ],
       path: PATH_RULE,
     },
@@ -100,16 +95,6 @@
         return node.parentElement;
       });
       node.click();
-    },
-  });
-
-  _.register({
-    rule: {
-      host: /^chronos\.to$/,
-      path: PATH_RULE,
-    },
-    async ready (m) {
-      await helper(m.path[1], getNext2);
     },
   });
 


### PR DESCRIPTION
domains are gone:
- imguniversal.com
- imgpaying.com
- imgmega.com
- imgzeus.com
- imgmaid.net
- imzdrop.com
- imgdrive.co
- cuteimg.cc
- imgtiger.org
- imggold.org
- myimg.club
- foxyimg.link
- coreimg.net
- chronos.to