### PR TITLE
Update imgfantasy.js

### DIFF
--- a/src/sites/image/imgfantasy.js
+++ b/src/sites/image/imgfantasy.js
@@ -3,11 +3,9 @@
   _.register({
     rule: {
       host: [
-        /^img(fantasy|leech|\.pornleech|smile|nemo|sense|curl)\.com$/,
-        /^(imagedomino|lovechix|imagebic)\.com$/,
+        /^img(fantasy|smile|nemo|curl)\.com$/,
+        /^(imagedomino|lovechix)\.com$/,
         /^0img\.net$/,
-        /^daily-img\.com$/,
-        /^picangel\.in$/,
         /^bunnyforum\.org$/,
       ],
       query: /^\?[pv]=/,


### PR DESCRIPTION
domains gone:
- imgleech.com
- img.pornleech.com
- imgsense.com
- imagebic.com
- daily-img.com
- picangel.in