### PR TITLE
Update shortenurl.tk.js

### DIFF
--- a/src/sites/link/shortenurl.tk.js
+++ b/src/sites/link/shortenurl.tk.js
@@ -1,9 +1,6 @@
 _.register({
   rule: {
     host: [
-      /^(www\.)?shortenurl\.tk$/,
-      /^(www\.)?pengaman\.link$/,
-      /^urlgo\.gs$/,
       /^gunting\.web\.id$/,
     ],
     path: /^\/\w+$/,


### PR DESCRIPTION
domains gone:
- shortenurl.tk
- pengaman.link
- urlgo.gs