### PR TITLE
Update sh.st.js

### DIFF
--- a/src/sites/link/sh.st.js
+++ b/src/sites/link/sh.st.js
@@ -2,11 +2,9 @@
 
   const hostRules = [
     /^sh\.st$/,
-    /^(dh10thbvu|u2ks|jnw0|qaafa|xiw34|cllkme|clkmein|corneey|ceesty)\.com$/,
+    /^(dh10thbvu|u2ks|jnw0|xiw34|cllkme|clkmein|corneey|ceesty)\.com$/,
     /^[dfg]estyy\.com$/,
-    /^digg\.to$/,
     /^([vw]iid|clkme)\.me$/,
-    /^short\.est$/,
   ];
 
   _.register({


### PR DESCRIPTION
domains gone:
- qaafa.com
- digg.to
- short.est