### PR TITLE
Update mantap.in.js

### DIFF
--- a/src/sites/link/mantap.in.js
+++ b/src/sites/link/mantap.in.js
@@ -1,10 +1,7 @@
 _.register({
   rule: {
     host: [
-      /^mant[ae][pb]\.in$/,
-      /^st\.oploverz\.net$/,
       /^minidroid\.net$/,
-      /^ww3\.awaremmxv\.com$/,
       /^linkpoi\.in$/,
     ],
   },


### PR DESCRIPTION
domains gone:
- mantap.in
- mantab.in
- mantep.in
- manteb.in
- st.oploverz.net
- awaremmxv.com