### PR TITLE
Update link4ad.com.js

### DIFF
--- a/src/sites/link/link4ad.com.js
+++ b/src/sites/link/link4ad.com.js
@@ -1,6 +1,6 @@
 _.register({
   rule: {
-    host: /^link(4ad|ajc)\.com$/,
+    host: /^link4ad\.com$/,
     path: /^\/(.+)$/,
   },
   async ready (m) {


### PR DESCRIPTION
domain gone:
- linkajc.com