### PR TITLE
Update imagescream.com.js

### DIFF
--- a/src/sites/image/imagescream.com.js
+++ b/src/sites/image/imagescream.com.js
@@ -1,33 +1,6 @@
 _.register({
-  rule: [
-    {
-      host: /^imagescream\.com$/,
-      path: /^\/img\/(soft\/)?/,
-    },
-    {
-      host: /^(www\.)?picturescream\.com$/,
-      path: /^\/x\//,
-    },
-    {
-      host: /^picturescream\.asia$/,
-    },
-    {
-      host: /^postscreens\.info/,
-      path: /^\/.*/,
-    },
-  ],
-  async ready () {
-    const i = $('#shortURL-content img');
-    await $.openImage(i.src);
-  },
-});
-
-_.register({
   rule: {
-    host: [
-      /^imagescream\.com$/,
-      /^all-poster\.ru$/,
-    ],
+    host: /^all-poster\.ru$/,
     query: /^\?v=/,
   },
   async ready () {


### PR DESCRIPTION
domains gone:
- imagescream.com
- picturescream.com
- picturescream.asia
- postscreens.info