### PR TITLE
Update sh.st.js

### DIFF
--- a/src/sites/link/sh.st.js
+++ b/src/sites/link/sh.st.js
@@ -2,7 +2,7 @@
 
   const hostRules = [
     /^sh\.st$/,
-    /^(dh10thbvu|u2ks|jnw0|xiw34|cllkme|clkmein|corneey|ceesty)\.com$/,
+    /^(jnw0|cllkme|clkmein|corneey|ceesty)\.com$/,
     /^[dfg]estyy\.com$/,
     /^([vw]iid|clkme)\.me$/,
   ];


### PR DESCRIPTION
domain gone:
- dh10thbvu.com
- u2ks.com

deceptive domain:
- xiw34.com