### PR TITLE
Add comandotorrents.com

### DIFF
--- a/src/sites/file/comandotorrents.com.js
+++ b/src/sites/file/comandotorrents.com.js
@@ -1,0 +1,19 @@
+_.register({
+  rule: {
+    host: /^www\.comandotorrents\.com$/,
+    path: /\/[\w-]+\/$/,
+  },
+  async ready () {
+    let mod;
+    const l = $.$$('p > a');
+    for (let i=0; i < l.length; i++) {
+      if (l[i].hasAttribute('href') && l[i].getAttribute('href').match(/\?id=(.+)$/)) {
+        mod = l[i].getAttribute('href');
+        mod = mod.match(/\?id=(.+)$/);
+        mod = atob(mod[1].split('').reverse().join(''));
+        document.querySelectorAll('p > a')[i].removeAttribute('target');
+        document.querySelectorAll('p > a')[i].setAttribute('href', mod);
+      }
+    }
+  },
+});


### PR DESCRIPTION
Direct link modification for #1981

I don't sure if this is permitted. Taking this approach, because I can't get the first link before the page redirect to another one.
If there is another solution, feel free to close this PR. ;)