### PR TITLE
clk.icu – another ClicksFly domain

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -44,7 +44,7 @@
         /^(shink|shrten|gg-l|vnurl)\.xyz$/,
         /^mlink\.club$/,
         /^(igram|gram)\.im$/,
-        /^(clk|cll)\.(press|sh)$/,
+        /^(clk|cll)\.(press|sh|icu)$/,
         /^short\.pe$/,
         /^urlcloud\.us$/,
         /^(123link|clik|tokenfly|getlink|psl)\.pw$/,


### PR DESCRIPTION
### Added clk.icu
fixes #2615.