### PR TITLE
Add fopkodiak.site and xxx.fopkodiak.site

### DIFF
--- a/src/sites/image/fopkodiak.site.js
+++ b/src/sites/image/fopkodiak.site.js
@@ -1,6 +1,7 @@
 _.register({
   rule: {
     host: /^fopkodiak\.site$/,
+    path: /image\//,
   },
   async ready () {
     let img = $("head > link[rel=image_src]");

--- a/src/sites/image/fopkodiak.site.js
+++ b/src/sites/image/fopkodiak.site.js
@@ -4,7 +4,7 @@ _.register({
     path: /image\//,
   },
   async ready () {
-    let img = $("head > link[rel=image_src]");
+    const img = $('head > link[rel=image_src]');
     await $.openImage(img.href);
   }
 });

--- a/src/sites/image/fopkodiak.site.js
+++ b/src/sites/image/fopkodiak.site.js
@@ -1,7 +1,7 @@
 _.register({
   rule: {
     host: /^fopkodiak\.site$/,
-    path: /image\//,
+    path: /^\/image\//,
   },
   async ready () {
     const img = $('head > link[rel=image_src]');

--- a/src/sites/image/fopkodiak.site.js
+++ b/src/sites/image/fopkodiak.site.js
@@ -1,0 +1,9 @@
+_.register({
+  rule: {
+    host: /^fopkodiak\.site$/,
+  },
+  async ready () {
+    let img = $("head > link[rel=image_src]");
+    await $.openImage(img.href);
+  }
+});

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -1,6 +1,7 @@
 _.register({
   rule: {
     host: /^xxx\.fopkodiak\.site$/,
+    path: /img-.*/,
   },
   async ready () {
     if (document.referrer == document.location.href) {

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -6,7 +6,7 @@ _.register({
   async ready () {
     if (document.referrer == document.location.href) {
       let img = $.$('#container > a > img');
-      if (img === null) {
+      if (!img) {
         img = $('#container > img');
       }
       await $.openImage(img.src);

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -5,16 +5,16 @@ _.register({
   },
   async ready () {
     if (document.referrer == document.location.href) {
-      let img = $.$("#container > a > img");
+      let img = $.$('#container > a > img');
       if (img === null) {
-        img = $("#container > img");
+        img = $('#container > img');
       }
       await $.openImage(img.src);
     } else {
-      let f = $("form");
+      const f = $('form');
       await $.openLink(f.action, { 
         post: {
-          imgContinue: "Continue to image ...",
+          imgContinue: 'Continue to image ...',
         }
       });
     }

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -1,7 +1,7 @@
 _.register({
   rule: {
     host: /^xxx\.fopkodiak\.site$/,
-    path: /img-.*/,
+    path: /^\/img-/,
   },
   async ready () {
     if (document.referrer == document.location.href) {

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -1,0 +1,18 @@
+_.register({
+  rule: {
+    host: /^xxx\.fopkodiak\.site$/,
+  },
+  async ready () {
+    if (document.referrer == document.location.href) {
+      let img = $("#container > a > img");
+      $.openImage(img.src);
+    } else {
+      let f = $("form");
+      await $.openLink(f.action, { 
+        post: {
+          imgContinue: "Continue to image ...",
+        }
+      });
+    }
+  }
+});

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -5,7 +5,7 @@ _.register({
   async ready () {
     if (document.referrer == document.location.href) {
       let img = $("#container > a > img");
-      $.openImage(img.src);
+      await $.openImage(img.src);
     } else {
       let f = $("form");
       await $.openLink(f.action, { 

--- a/src/sites/image/xxx.fopkodiak.site.js
+++ b/src/sites/image/xxx.fopkodiak.site.js
@@ -5,7 +5,10 @@ _.register({
   },
   async ready () {
     if (document.referrer == document.location.href) {
-      let img = $("#container > a > img");
+      let img = $.$("#container > a > img");
+      if (img === null) {
+        img = $("#container > img");
+      }
       await $.openImage(img.src);
     } else {
       let f = $("form");


### PR DESCRIPTION
This adds support for fopkodiak.site and xxx.fopkodiak.site images.

These websites are overloaded with ads and the xxx site requires manual interaction to continue.

Examples (I have tried to find the least inappropriate ones, but they are all slightly NSFW):

`http://fopkodiak.site/image/4ZldB`
`http://xxx.fopkodiak.site/img-5c472e2022768.html`

I'd like to warn you, the ads are full-on NSWF!