### PR TITLE
TEMP: Fix endless reloading

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -189,7 +189,7 @@
     }
 
     async call () {
-      const ok = this.prepare();
+      const ok = await this.prepare();
       if (!ok) {
         return;
       }
@@ -240,7 +240,7 @@
       super();
     }
 
-    prepare () {
+    async prepare () {
       this.removeOverlay();
 
       const f = $.$('#captchaShortlink');
@@ -255,10 +255,6 @@
       if (!b) {
         return false;
       }
-
-      if (!b.disabled) {
-        b.click();
-      }
       
       const o = new MutationObserver(() => {
         if (!b.disabled) {
@@ -268,6 +264,13 @@
       o.observe(b, {
         attributes: true,
       });
+
+      await _.wait(1000);
+      const click = f.clientWidth === 0 || f.childNodes.length === 0;
+      if (click && !b.disabled) {
+        _.info('clicking submit button, because recaptcha was empty');
+        b.click();
+      }
 
       return false;
     }


### PR DESCRIPTION
Some pages did endless reloading (e.g. buyitonline.store ), because b was detected as disabled but there was still a recaptcha.
It is better to check after 1s if the recaptcha is empty and b is still enabled.

TEMP because setTimeout does not seem like the adbypasser way, but my experiments with async and await did not work. Please explain to me how I can do it or feel free to push to my branch.

This is critical, because it makes the site unusable with adbypasser enabled (the change is only on develop branch right now). 