### PR TITLE
Fix endless reloading for slow internet connections

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -29,7 +29,7 @@
         /^(earn-url|bit-url|cut-win|link-zero|cut-earn|oturl|glory-link)\.com$/,
         /^(vy\.)?adsvy\.com$/,
         /^(linkexa|admew|shrtfly|kuylink|cut4links|adskipme|skipurls)\.com$/,
-        /^(cutpaid|smarteasystudy|cyahealth|ershadat|z2i|srtfly|arba7kpro)\.com$/,
+        /^(smarteasystudy|cyahealth|ershadat|z2i|srtfly|arba7kpro)\.com$/,
         /^(blogginggyanbox|yourtechguider|gifsis|3rab-cash|pinkhindi)\.com$/,
         /^(mykinggo|li-nkz|win4cut|khabratk|programsfre|safelinkblogger)\.com$/,
         /^(linkorlink|mrfourtech|fabsdeals|tech4utoday|urlsamo|icutlink)\.com$/,
@@ -60,7 +60,6 @@
         /^(koylinks|buy-in-599rs)\.win$/,
         /^lopte\.pro$/,
         /^(www\.)?pnd\.tl$/,
-        /^(www\.)?shrink\.vip$/,
         /^(tny|tiny)\.ec$/,
         /^tl\.tc$/,
         /^e2s\.cc$/,
@@ -93,6 +92,8 @@
       host: [
         /^wi\.cr$/,
         /^wicr\.me$/,
+        /^linksoflife\.co$/,
+        /^linksof\.life$/,
       ],
     },
     async ready () {
@@ -104,7 +105,10 @@
   _.register({
     rule: {
       host: [
+        /^cutpaid\.com$/,
+        /^ctui\.in$/,
         /^zutrox\.link$/,
+        /^(www\.)?shrink\.vip$/,
       ],
     },
     async ready () {

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -283,12 +283,13 @@
         return false;
       }
 
+      // InvisibleRecaptchaHandler needs the f element
       await this.submitListen(b, f);
 
       return false;
     }
 
-    async submitListen (b, f) {
+    async submitListen (b) {
       const o = new MutationObserver(() => {
         if (!b.disabled) {
           b.click();
@@ -351,9 +352,10 @@
       super();
     }
 
-    async submitListen (b, f) {
+    async submitListen (b) {
       while (true) {
         await _.wait(500);
+        /*global grecaptcha*/
         if (grecaptcha && grecaptcha.getResponse().length !== 0) {
           b.click();
           break;

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -43,7 +43,7 @@
         /^(www\.)?lwt\.pw$/,
         // else
         /^(trlink|wolink|tocdo|cuturl|counsellingresult2016|iitjeemainguide)\.in$/,
-        /^(petty|skips|tr|zutrox|flaz)\.link$/,
+        /^(petty|skips|tr|flaz)\.link$/,
         /^megaurl\.(in|link)$/,
         /^(adbilty|adpop|ujv|tpx|adsrt|2fly|lin65)\.me$/,
         /^payskip\.(me|org)$/,
@@ -97,6 +97,18 @@
     },
     async ready () {
       const handler = new InvisibleRecaptchaHandler();
+      await handler.call();
+    },
+  });
+
+  _.register({
+    rule: {
+      host: [
+        /^zutrox\.link$/,
+      ],
+    },
+    async ready () {
+      const handler = new NonDisabledRecaptchaHandler();
       await handler.call();
     },
   });
@@ -327,6 +339,25 @@
       if (click && !b.disabled) {
         _.info('clicking submit button, because recaptcha was empty');
         b.click();
+      }
+    }
+
+  }
+
+
+  class NonDisabledRecaptchaHandler extends RecaptchaHandler {
+
+    constructor () {
+      super();
+    }
+
+    async submitListen (b, f) {
+      while (true) {
+        await _.wait(500);
+        if (grecaptcha && grecaptcha.getResponse().length !== 0) {
+          b.click();
+          break;
+        }
       }
     }
 

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -45,8 +45,7 @@
         /^(trlink|wolink|tocdo|cuturl|counsellingresult2016|iitjeemainguide)\.in$/,
         /^(petty|skips|tr|zutrox|flaz)\.link$/,
         /^megaurl\.(in|link)$/,
-        /^(adbilty|adpop|wicr|ujv|tpx|adsrt|2fly|lin65)\.me$/,
-        /^wi\.cr$/,
+        /^(adbilty|adpop|ujv|tpx|adsrt|2fly|lin65)\.me$/,
         /^payskip\.(me|org)$/,
         /^(oke|cuon|cuio|cuee|cuus|cuto|linktor|flylink|uiz)\.io$/,
         /^(3bst|coinlink|itiurl|coshink|link5s|curs)\.co$/,
@@ -85,6 +84,19 @@
     },
     async ready () {
       const handler = new RecaptchaHandler();
+      await handler.call();
+    },
+  });
+
+  _.register({
+    rule: {
+      host: [
+        /^wi\.cr$/,
+        /^wicr\.me$/,
+      ],
+    },
+    async ready () {
+      const handler = new InvisibleRecaptchaHandler();
       await handler.call();
     },
   });
@@ -258,7 +270,13 @@
       if (!b) {
         return false;
       }
-      
+
+      await this.submitListen(b, f);
+
+      return false;
+    }
+
+    async submitListen (b, f) {
       const o = new MutationObserver(() => {
         if (!b.disabled) {
           b.click();
@@ -267,15 +285,6 @@
       o.observe(b, {
         attributes: true,
       });
-
-      await _.wait(1000);
-      const click = f.clientWidth === 0 || f.childNodes.length === 0;
-      if (click && !b.disabled) {
-        _.info('clicking submit button, because recaptcha was empty');
-        b.click();
-      }
-
-      return false;
     }
 
     async getMiddleware () {
@@ -300,6 +309,24 @@
         } catch (e) {
           _.warn(e);
         }
+      }
+    }
+
+  }
+
+
+  class InvisibleRecaptchaHandler extends RecaptchaHandler {
+
+    constructor () {
+      super();
+    }
+
+    async submitListen (b, f) {
+      await _.wait(1000);
+      const click = f.clientWidth === 0 || f.childNodes.length === 0;
+      if (click && !b.disabled) {
+        _.info('clicking submit button, because recaptcha was empty');
+        b.click();
       }
     }
 
@@ -388,7 +415,7 @@
 
   class ShortlyHandler extends AbstractHandler {
 
-    constructor() {
+    constructor () {
       super();
     }
 


### PR DESCRIPTION
Ok what I did:

1. Extracted waiting for submit button to new method.
2. Added wicr.me to new InvisibleRecaptcha class, so other sites don't endlessy reload when the user has slow internet.
3.  Added zutrox to NonDisabledRecaptcha class, that can submit after the user solved recaptchas, when the submit button is always enabled (the normal Recaptcha class detected solved recaptchtas when the submit button went from disabled to enabled)