### PR TITLE
Add Blog.langw.web.id

### DIFF
--- a/src/sites/link/blog.langw.web.id.js
+++ b/src/sites/link/blog.langw.web.id.js
@@ -1,0 +1,13 @@
+_.register({
+  rule: {
+    host: /^blog\.langw\.web\.id$/,
+  },
+  async ready () {
+    const url = decodeURIComponent(decodeURIComponent($.getCookie('wpb_visit_time')));
+    if (url.match(/^http/)) {
+      $.resetCookies();
+      await $.openLink(url);
+    }
+    // TODO handling of the countdown, when no url found
+  },
+});


### PR DESCRIPTION
e.g. 

http://blog.langw.web.id/safeme/?url=https%3A%2F%2Fmirrorace.com%2Fm%2Feb71


Sadly you cannot hook into the site when it is as that location, as it gets a http redirect. Luckily the original url param is still stored in the cookies