### PR TITLE
Create gamemod.pro.js

### DIFF
--- a/src/sites/link/gamemod.pro.js
+++ b/src/sites/link/gamemod.pro.js
@@ -1,0 +1,10 @@
+_.register({
+  rule: {
+    host: /^gamemod\.pro$/,
+    path: /^\/download-file\//,
+  },
+  async ready () {
+    const gp = $('#wait-done > p > a');
+    await $.openLink(gp.href);
+  },
+});


### PR DESCRIPTION
close #2903

It would be even better, if it can be checked whether the `a.href` link contains `?api=*&url=*`; and if yes then open the link after `url=`, otherwise just open the whole link.