### PR TITLE
[Fix] Tor crashes on mirrored.to

### DIFF
--- a/src/sites/file/mirrorcreator.com.js
+++ b/src/sites/file/mirrorcreator.com.js
@@ -28,7 +28,8 @@ _.register({
     res.style.display = 'block';
 
     const o = new MutationObserver(() => {
-      res.style.display = 'block'; //never hide me again
+      if(res.style.display != 'block')
+        res.style.display = 'block'; //never hide me again
     });
     o.observe(res, {
       attributes: true,


### PR DESCRIPTION
When using Tor Browser, mirrored.to download pages are caught in an infinite loop, which makes the browser increase memory until it runs out and crashes. The culprit is this part:

```js
    const o = new MutationObserver(() => {
      res.style.display = 'block'; //never hide me again
    });
```
Applying `res.style.display = 'block';` triggers the observer, which applies `res.style.display = 'block';` which triggers the observer, etc. 

It seems this doesn't happen with regular Firefox. I don't know why.

This PR fixes the issue, by not setting `display = 'bock'` if it is already `block`.

([Sample link](https://www.mirrored.to/files/2SMLCF2I/LEGO__Batman__2_[ALBEWRWR].part21.rar_links))