### PR TITLE
Add support for picdollar.com

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -285,6 +285,7 @@
     * kvador.com
     * pic-maniac.com
     * picbaron.com
+    * picdollar.com
     * uimgshare.com
     * uploadrr.com
 * picexposed.com

--- a/src/sites/image/imgsee.me.js
+++ b/src/sites/image/imgsee.me.js
@@ -99,7 +99,7 @@
   _.register({
     rule: {
       host: [
-        /^(picbaron|imgbaron|kvador)\.com$/,
+        /^(picdollar|picbaron|imgbaron|kvador)\.com$/,
         /^imgfiles\.org$/,
       ],
       path: PATH_RULE,


### PR DESCRIPTION
Adds support for picdollar.com, an (adult) image hosting site.
This site uses the same logic as for picbaron.com and imgbaron.com.