### PR TITLE
Add support for imgweng.xyz

### DIFF
--- a/SITES.md
+++ b/SITES.md
@@ -970,6 +970,7 @@
     * imgfile.net
     * imgsee.net
     * imgsky.net
+    * imgweng.xyz
 * pics-money.ru
     * p0xpicmoney.ru
     * picker-click.ru

--- a/SITES.md
+++ b/SITES.md
@@ -970,7 +970,6 @@
     * imgfile.net
     * imgsee.net
     * imgsky.net
-    * imgweng.xyz
 * pics-money.ru
     * p0xpicmoney.ru
     * picker-click.ru

--- a/src/sites/image/imgvip.net.js
+++ b/src/sites/image/imgvip.net.js
@@ -17,6 +17,7 @@ _.register({
     {
       host: [
         /^www\.(imgsky|imgfile|imgsee)\.net$/,
+        /^imgweng\.xyz$/,
         /^www\.imagespicy\.site$/,
       ],
       path: /^\/[a-z|0-9]{4,10}$/,

--- a/src/sites/image/imgvip.net.js
+++ b/src/sites/image/imgvip.net.js
@@ -17,8 +17,8 @@ _.register({
     {
       host: [
         /^www\.(imgsky|imgfile|imgsee)\.net$/,
-        /^imgweng\.xyz$/,
         /^www\.imagespicy\.site$/,
+        /^(imgxen|imgweng)\.xyz$/,
       ],
       path: /^\/[a-z|0-9]{4,10}$/,
     },


### PR DESCRIPTION
This pull request fixes a newly added redirect by imgsee.net, imgsky.net, imgblaze.net and others.
Logic hasn't changed, just a new host has been added.

close: #3639