### PR TITLE
fix imagetwist downloading image

### DIFF
--- a/src/sites/image/imagetwist.js
+++ b/src/sites/image/imagetwist.js
@@ -25,7 +25,9 @@
 
   async function run () {
     const i = $('img.pic');
-    await $.openImage(i.src);
+    await $.openImage(i.src, {
+      replace: true,
+    });
   }
 
 })();


### PR DESCRIPTION
Today it happened that Imagetwist tries to download images if opened directly.

This patch is fixing that behaviour.