### PR TITLE
add imgneor.store to imgvip.net.js

### DIFF
--- a/src/sites/image/imgvip.net.js
+++ b/src/sites/image/imgvip.net.js
@@ -47,6 +47,7 @@ _.register({
         /^(hfneiott|lgjreelqq|pyotinle|pixmtke|optiye)\.buzz$/,
         /^imgpuloki\.online$/,
         /^(picuekr|imglekw)\.site/,
+        /^imgneor\.store$/,
       ],
       path: /^\/[a-z|0-9]{4,10}$/,
     },


### PR DESCRIPTION
add imgneor.store to imgvip.net.js

some http://imgblaze.net is redirect to imgneor.store