### PR TITLE
Update linkdrop.net.js

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -122,7 +122,6 @@
         /^earn\.theplusit\.ro$/,
         /^tinylink\.run$/,
         /^(oko|aii|shorten)\.sh$/,
-        /^(dutchycorp|abouttech)\.space$/,
         /^buyitonline\.store$/,
         /^eatings\.stream$/,
         /^tl\.tc$/,

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -169,7 +169,6 @@
         /^zutrox\.link$/,
         /^(techcraze|healthinsider)\.online$/,
         /^cutwin\.(us|com)$/,
-        /^(www\.)?shrink\.vip$/,
       ],
     },
     async ready () {

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -91,7 +91,6 @@
         /^(icutit|earnbig|cutearn)\.ca$/,
         /^e2s\.cc$/,
         /^(adzurl|link2link)\.cf$/,
-        /^(mlink|cl250|xpickle|infosehatku)\.club$/,
         /^(3bst|coinlink|itiurl|coshink|link5s|curs|makeurl|mooddisorder|cutls)\.co$/,
         /^bestscholaeshipdegree\.date$/,
         /^click2see\.desi$/,

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -125,7 +125,6 @@
         /^tl\.tc$/,
         /^(1921681254|geki|wegner|gpshort)\.tech$/,
         /^(linkvip|4short)\.tk$/,
-        /^(www\.)?pnd\.tl$/,
         /^(urlcloud|imageoptimizer)\.us$/,
         /^(koylinks|buy-in-599rs)\.win$/,
         /^exe\.(io|app)$/,

--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -120,7 +120,6 @@
         /^royalown\.review$/,
         /^earn\.theplusit\.ro$/,
         /^tinylink\.run$/,
-        /^(oko|aii|shorten)\.sh$/,
         /^buyitonline\.store$/,
         /^eatings\.stream$/,
         /^tl\.tc$/,


### PR DESCRIPTION
close #3103, #3156, #3282, #3456 and #3628. Domains are gone.