### PR TITLE
Update and rename ifotos.pl.js to img.javstore.net.js

### DIFF
--- a/src/sites/image/img.javstore.net.js
+++ b/src/sites/image/img.javstore.net.js
@@ -1,8 +1,5 @@
 _.register({
   rule: [
-    'http://ifotos.pl/zobacz/*',
-    'https://postimg.cc/*',
-    'https://pixxxels.cc/*',
     'https://img.javstore.net/image/*',
     'https://picnew.space/image/*',
     'https://pig69.com/*',


### PR DESCRIPTION
ifotos.pl has shut down. img.javstore and picnew still active and working. 
postimg and pixxxels are working with new code created in #3857. 