### PR TITLE
Update linkdrop.net.js

### DIFF
--- a/src/sites/link/linkdrop.net.js
+++ b/src/sites/link/linkdrop.net.js
@@ -79,7 +79,6 @@
         /^(shink|shrten|gg-l|vnurl|bloggingdekh|ln11|sh11|tradeguru|newskart|kidsors|xz2)\.xyz$/,
         /^(techinhub|viralnow|shophipro|technocanvas|getfreshcloud|profitstudy|ijobanana)\.xyz$/,
         /^(autocarsmagz|getpocket|yasinews|dunyanews|komiupdates|allapp|smwebs|news-tech)\.xyz$/,
-        /^cutdl\.xyz$/,
         // else
         /^(ckk|iir|tii)\.ai$/,
         /^get\.ujv\.al$/,


### PR DESCRIPTION
close #3707 #3670 #3785

Mitly has no bug. You do have to press 'Click here to continue' after the captcha, but it is automatic after that.  
https://mitly.us/BGHJIOF/

Birdurls works fine, you just have to wait for a countdown. https://birdurls.com/abifNs1f

Cutdl can be removed, it goes directly to the destination with nothing to bypass. https://cutdl.xyz/ROf5XpNl
