### PR TITLE
fix: check script handler

### DIFF
--- a/infra/userscript/metadata.template.js
+++ b/infra/userscript/metadata.template.js
@@ -14,6 +14,7 @@
 // @grant          GM_getResourceURL
 <% } %>
 // @grant          GM_getValue
+// @grant          GM_info
 // @grant          GM_openInTab
 // @grant          GM_registerMenuCommand
 // @grant          GM_setValue
@@ -23,6 +24,7 @@
 // @grant          GM.getResourceUrl
 <% } %>
 // @grant          GM.getValue
+// @grant          GM.info
 // @grant          GM.openInTab
 // @grant          GM.setValue
 // @grant          GM.xmlHttpRequest

--- a/src/util/platform.js
+++ b/src/util/platform.js
@@ -81,15 +81,26 @@ function getGreaseMonkeyAPI () {
   return gm;
 }
 
+
+function getGMInfo () {
+  if (typeof GM_info === "object" && GM_info) {
+    return GM_info;
+  } else if (typeof GM === 'object' && GM && GM.info) {
+    return GM.info;
+  } else {
+    return {};
+  }
+}
+
+
 // magic property to get the original object
 const MAGIC_KEY = '__adsbypasser_reverse_proxy__';
 
 
 function getUnsafeWindowProxy () {
-  const isFirefox = typeof InstallTrigger !== 'undefined';
-  // Violentmonkey does not need the wrapper
-  if (!isFirefox) {
-    // other browsers does not need this
+  const isGreaseMonkey = getGMInfo().scriptHandler === 'Greasemonkey';
+  // Only GreaseMonkey need this wrapper
+  if (!isGreaseMonkey) {
     return rawUSW;
   }
 


### PR DESCRIPTION
close #3541

For now only GreaseMonkey need this proxy.
Although this proxy only works on Firefox, GreaseMonkey does not support other browsers anyway.