### PR TITLE
Fix imx

### DIFF
--- a/src/sites/image/acidimg.cc.js
+++ b/src/sites/image/acidimg.cc.js
@@ -9,6 +9,11 @@ _.register({
     let a = $.$('#continuebutton, .button');
     if (a) {
       a.click();
+    } else {
+      a = $.$('#imgContinue, .button');
+      if (a) {
+        a.click();
+      }
     }
     a = $('.centred');
     await $.openImage(a.src);


### PR DESCRIPTION
this fixes imx.to new button which is often seen (but the old version with continue on top is also existing).

But I have a weird problem in Brave. The whole script won't run when injected with Tampermonkey. Somehow the Brave adblocker or the anti-adblocker script from imx.to (unsure what the reason is) blocks this script but only on imx.to (no problem with brave and this script on other image sites). I had to turn of adblocking on imx.to to get it running.