### PR TITLE
Referer detection fix for imgair.net.js

### DIFF
--- a/src/sites/image/imgair.net.js
+++ b/src/sites/image/imgair.net.js
@@ -13,6 +13,6 @@ _.register({
     },
   async ready () {
     const matches = $.searchFromScripts(/imgbg\.src = "([^"]+)";/);
-    await $.openImage(matches[1]);
+    await $.openImage(matches[1], { referer: true });
   },
 });


### PR DESCRIPTION
They're currently Checking the availability of the referer header. Otherwise, HTTP 404 will returned.

example link **(WARNING: NSFW)** https://imgfrost.net/6mvns4xe (imgfrost.net > redirect to imgouhmde.sbs or imgair.net or else > prcf.imglomalr.site or else)

double-check(i didn't build it for test) will required.