### PR TITLE
Fix ibb.com redirect to small resolution image

### DIFF
--- a/src/sites/image/imgbb.com.js
+++ b/src/sites/image/imgbb.com.js
@@ -6,7 +6,7 @@ _.register({
     ],
   },
   async ready () {
-    const img = $('.image-viewer-container img');
-    await $.openImage(img.src);
+    const img = $('meta[property="og:image"]');
+    await $.openImage(img.content);
   },
 });


### PR DESCRIPTION
Look into (original image)
`<meta property="og:image" content="https://i.ibb.co/...." /> `
instead of (resized)
`<img src="https://i.ibb.co/..." alt="..." width="1920" height="1080" data-is360="0" data-load="full"> `


