### PR TITLE
chore: add domain diff extract script

### DIFF
--- a/build/diff.js
+++ b/build/diff.js
@@ -1,0 +1,179 @@
+import { execSync } from "child_process";
+import { extractDomainsFromJSDoc } from "./jsdoc.js";
+
+/**
+ * Extract domains from JSDoc at a specific git tag using git show
+ * @param {string} tag - Git tag
+ * @returns {Promise<Set<string>>} Set of domain names
+ */
+async function extractDomainsFromJSDocAtTag(tag) {
+  const domains = new Set();
+
+  try {
+    // Get all .js files in src/sites at the specific tag
+    const files = execSync(`git ls-tree -r --name-only ${tag} src/sites/`, {
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter((line) => line.trim() && line.endsWith(".js"));
+
+    for (const file of files) {
+      try {
+        // Read file content at the specific tag
+        const content = execSync(`git show ${tag}:${file}`, {
+          encoding: "utf8",
+        });
+        const fileDomains = extractDomainsFromContent(content);
+        fileDomains.forEach((domain) => domains.add(domain));
+      } catch (error) {
+        // Skip files that can't be read (deleted, renamed, etc.)
+        console.warn(
+          `Warning: Could not read ${file} at ${tag}: ${error.message}`,
+        );
+      }
+    }
+  } catch (error) {
+    throw new Error(`Failed to read files at tag ${tag}: ${error.message}`);
+  }
+
+  return domains;
+}
+
+/**
+ * Extract domains from file content using JSDoc @domain tags
+ * @param {string} content - File content
+ * @returns {string[]} Array of domain names
+ */
+function extractDomainsFromContent(content) {
+  const domains = [];
+  const domainRegex = /@domain\s+([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/g;
+  let match;
+
+  while ((match = domainRegex.exec(content)) !== null) {
+    const domain = match[1].trim();
+    if (isValidDomain(domain)) {
+      domains.push(domain);
+    }
+  }
+
+  return domains;
+}
+
+/**
+ * Validate domain name format
+ * @param {string} domain - Domain to validate
+ * @returns {boolean} True if valid domain
+ */
+function isValidDomain(domain) {
+  // Basic domain validation - contains dots and valid characters
+  return /^[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/.test(domain);
+}
+
+/**
+ * Extract domains at a specific git tag or HEAD
+ * @param {string} tag - Git tag or 'HEAD'
+ * @returns {Promise<Set<string>>} Set of domain names
+ */
+async function extractDomainsAtTag(tag) {
+  if (tag === "HEAD") {
+    // Use current working directory
+    const domains = await extractDomainsFromJSDoc();
+    return new Set(domains);
+  } else {
+    // Use git show to read files without checking out
+    return await extractDomainsFromJSDocAtTag(tag);
+  }
+}
+
+/**
+ * Compare two domain sets to find added and retired domains
+ * @param {Set<string>} oldDomains - Domains from older tag
+ * @param {Set<string>} newDomains - Domains from newer tag
+ * @returns {Object} Object with added and retired Sets
+ */
+function compareDomains(oldDomains, newDomains) {
+  const added = new Set();
+  const retired = new Set();
+
+  // Find added domains (in new but not in old)
+  for (const domain of newDomains) {
+    if (!oldDomains.has(domain)) {
+      added.add(domain);
+    }
+  }
+
+  // Find retired domains (in old but not in new)
+  for (const domain of oldDomains) {
+    if (!newDomains.has(domain)) {
+      retired.add(domain);
+    }
+  }
+
+  return { added, retired };
+}
+
+/**
+ * Extract fixed domains from git commit messages between two tags
+ * @param {string} fromTag - Starting tag
+ * @param {string} toTag - Ending tag
+ * @param {Set<string>} existingDomains - Domains that exist in both tags
+ * @returns {Set<string>} Set of fixed domain names
+ */
+function extractFixedDomains(fromTag, toTag, existingDomains) {
+  const fixed = new Set();
+
+  try {
+    // Get commits between tags
+    const commitRange =
+      toTag === "HEAD" ? `${fromTag}..HEAD` : `${fromTag}..${toTag}`;
+    const commits = execSync(`git log ${commitRange} --oneline`, {
+      encoding: "utf8",
+    })
+      .split("\n")
+      .filter((line) => line.trim());
+
+    for (const commit of commits) {
+      // Look for fix: patterns (fixes)
+      const fixMatch = commit.match(/fix:\s*([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/);
+      if (fixMatch) {
+        const domain = fixMatch[1].trim();
+        if (isValidDomain(domain) && existingDomains.has(domain)) {
+          fixed.add(domain);
+        }
+      }
+    }
+  } catch (error) {
+    console.warn(`Warning: Could not analyze commits: ${error.message}`);
+  }
+
+  return fixed;
+}
+
+/**
+ * Generate changelog data between two git tags
+ * @param {string} fromTag - Starting tag
+ * @param {string} toTag - Ending tag
+ * @returns {Promise<Object>} Object with added, retired, fixed arrays and metadata
+ */
+export async function extractDomainDiff(fromTag, toTag) {
+  const oldDomains = await extractDomainsAtTag(fromTag);
+  const newDomains = await extractDomainsAtTag(toTag);
+
+  const { added, retired } = compareDomains(oldDomains, newDomains);
+
+  // Find domains that exist in both tags for fixed domain detection
+  const existingDomains = new Set();
+  for (const domain of newDomains) {
+    if (oldDomains.has(domain)) {
+      existingDomains.add(domain);
+    }
+  }
+
+  const fixed = extractFixedDomains(fromTag, toTag, existingDomains);
+
+  return {
+    added: Array.from(added).sort(),
+    retired: Array.from(retired).sort(),
+    fixed: Array.from(fixed).sort(),
+  };
+}


### PR DESCRIPTION
This patch adds a new build script that I will use it to generate changelog for releases, so we don't need to update `CHANGELOG.md` manually. So that we can deprecate `CHANGELOG.md` later.

To generate release message, we need to extract the following domains from previous release to current release:
* added
* retired
* fixed

For `added` and `retired` we simply compares domain list in JSDoc.

For `fixed` there is no changes in the JSDoc, so we have to parse them from git commit message.
I propose to use this format:
```
fix: example.org
```
This is [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) which has been used in many organizations (e.g. [Angular](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#-commit-message-guidelines)). My recent commits have already follow this convention (e.g. ee2567d8b0f0c07da80c101505fa13b5d191fbae). I didn't and won't force this to all people.
If there is other good solution, your opinion are welcome.

If you merge PR by "Squash and Rebase", and the PR title has the domain name, then the commit message will be well formatted already.

If you edit the files from github web UI, this patch looks the "Commit Message", not extend information.
<img width="496" height="354" alt="Screenshot 2025-09-20 at 22 13 45" src="https://github.com/user-attachments/assets/02880294-5949-409b-8f13-122eeeff78b2" />
