### PR TITLE
Fix fastpic redirect loop

### DIFF
--- a/src/sites/image/fastpic.org.js
+++ b/src/sites/image/fastpic.org.js
@@ -4,9 +4,15 @@
 _.register({
   rule: {
     host: /^fastpic\.org$/,
+    path: /^\/view\//
   },
   async ready() {
-    const img = $("img.image.img-fluid");
-    await $.openImage(img.src);
+  const a = $.$("#imglink");
+  if (a) {
+    await $.openLink(a.href);
+    return;
+  }
+  const directUrl = $.searchFromScripts(/loading_img = '([^"]+)';/);
+  await $.openLink(directUrl[1]);
   },
 });


### PR DESCRIPTION
Fastpic auto-redirects `https://i{X}{X}.fastpic.org/big/` links back to `https://fastpic.org/view/` on certain links, causing a non-ending redirect loop when the script is enabled. This commit stops the script at the `https://fastpic.org/fullview/` link to avoid the loop. More details in #4106

