### PR TITLE
fix(nuke): body is null after implicit document.open(), link never rendered

### DIFF
--- a/src/lib/misc.js
+++ b/src/lib/misc.js
@@ -15,16 +15,24 @@ function removeAllTimer() {
 }
 
 function nuke(url) {
+  // document.write() mid-execution implicitly calls document.open(), which
+  // clears the current document *and removes document.body*. The subsequent
+  // document.body.appendChild(a) then throws on the null body, silently
+  // dropping the URL link. Do the full replace atomically instead: open the
+  // document once, write both the message and the link, then close.
+  const doc = usw.document;
+  const safeUrl = String(url).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c],
+  );
   try {
-    usw.document.write("nuked by AdsBypasser, leading to ...<br/>");
+    doc.open();
+    doc.write(
+      `nuked by AdsBypasser, leading to <a href="${safeUrl}">${safeUrl}</a>`,
+    );
+    doc.close();
   } catch (e) {
     warn("nuke failed", e);
   }
-
-  const a = document.createElement("a");
-  a.href = url;
-  a.textContent = url;
-  document.body.appendChild(a);
 }
 
 function generateRandomIP() {


### PR DESCRIPTION
`nuke()` in `src/lib/misc.js` writes a message via `document.write` then tries to append a link:

```js
try {
  usw.document.write("nuked by AdsBypasser, leading to ...<br/>");
} catch (e) { warn("nuke failed", e); }
const a = document.createElement("a");
a.href = url;
a.textContent = url;
document.body.appendChild(a);
```

Mid-execution `document.write` implicitly calls `document.open()`, which clears the document and removes `document.body`. The subsequent `document.body.appendChild(a)` then throws `TypeError: Cannot read properties of null (reading 'appendChild')`. The try/catch only wraps the write call, so the throw is uncaught — and the link is never added.

Fix: open/write/close in a single frame with the link written inline. HTML-escape the URL so ad-page-controlled URLs with quotes/tags cannot inject markup.

Repro (any modern Chrome/Firefox):
```js
document.write("hello");
document.body.appendChild(document.createElement("a"));
// -> TypeError: Cannot read properties of null (reading 'appendChild')
```

Thanks for the great work on AdsBypasser!